### PR TITLE
Include `event_id` in recorded event data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: elixir
 
 elixir:
-  - 1.4.2
+  - 1.5.2
 
 otp_release:
-  - 19.3
+  - 20.1
 
 sudo: required
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@
 
 ### Bug fixes
 
-- Fix compilation error with Commanded v0.14.0 due to removal of `Commanded.EventStore.TypeProvider` macro, replaced with runtime config lookup ([#5](https://github.com/slashdotdash/commanded-extreme-adapter/issues/5)).
+- Fix compilation error with Commanded v0.14.0 due to removal of `Commanded.EventStore.TypeProvider` macro, replaced with runtime config lookup ([#5](https://github.com/commanded/commanded-extreme-adapter/issues/5)).
 
 ## v0.2.0
 
 ### Enhancements
 
-- Raise an exception if `:stream_prefix` configuration contains a dash character ("-") as this does not work with subscriptions ([#3](https://github.com/slashdotdash/commanded-extreme-adapter/issues/3)).
+- Raise an exception if `:stream_prefix` configuration contains a dash character ("-") as this does not work with subscriptions ([#3](https://github.com/commanded/commanded-extreme-adapter/issues/3)).
 
 ## v0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Next release (v0.4.0)
+## v0.4.0
 
 - Include `event_id` in recorded event data.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Next release (v0.4.0)
+
+- Include `event_id` in recorded event data.
+
 ## v0.3.0
 
 ### Bug fixes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Extreme event store adapter for Commanded
 
-Use Greg Young's [Event Store](https://geteventstore.com/) with [Commanded](https://github.com/slashdotdash/commanded) using the [Extreme](https://github.com/exponentially/extreme) Elixir TCP client.
+Use Greg Young's [Event Store](https://geteventstore.com/) with [Commanded](https://github.com/commanded/commanded) using the [Extreme](https://github.com/exponentially/extreme) Elixir TCP client.
 
 ---
 
@@ -8,7 +8,7 @@ Use Greg Young's [Event Store](https://geteventstore.com/) with [Commanded](http
 
 MIT License
 
-[![Build Status](https://travis-ci.org/slashdotdash/commanded-extreme-adapter.svg?branch=master)](https://travis-ci.org/slashdotdash/commanded-extreme-adapter)
+[![Build Status](https://travis-ci.org/commanded/commanded-extreme-adapter.svg?branch=master)](https://travis-ci.org/commanded/commanded-extreme-adapter)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -44,10 +44,11 @@ The package can be installed from hex as follows.
       max_attempts: :infinity
     ```
 
-4. Configure the `commanded_extreme_adapter` to specify a stream prefix to be used by all Commanded event streams:
+4. Configure the `commanded_extreme_adapter` to specify the JSON serializer and a stream prefix to be used by all Commanded event streams:
 
     ```elixir
     config :commanded_extreme_adapter,
+      serializer: Commanded.Serialization.JsonSerializer,
       stream_prefix: "commandeddev"
     ```
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -10,4 +10,5 @@ config :extreme, :event_store,
   max_attempts: :infinity
 
 config :commanded_extreme_adapter,
+  serializer: Commanded.Serialization.JsonSerializer,
   stream_prefix: "commandeddev"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -10,4 +10,5 @@ config :extreme, :event_store,
   max_attempts: :infinity
 
 config :commanded_extreme_adapter,
+  serializer: Commanded.Serialization.JsonSerializer,
   stream_prefix: "commandedprod"

--- a/config/test.exs
+++ b/config/test.exs
@@ -12,6 +12,7 @@ config :extreme, :event_store,
   password: "changeit",
   reconnect_delay: 2_000,
   max_attempts: :infinity
-
+  
 config :commanded_extreme_adapter,
+  serializer: Commanded.Serialization.JsonSerializer,
   stream_prefix: "commandedtest"

--- a/lib/extreme.ex
+++ b/lib/extreme.ex
@@ -318,6 +318,7 @@ defmodule Commanded.EventStore.Adapters.Extreme do
     {correlation_id, metadata} = Map.pop(metadata, "$correlationId")
 
     %RecordedEvent{
+      event_id: ev.event_id,
       event_number: event_number,
       stream_id: to_stream_id(ev),
       stream_version: event_number,

--- a/lib/extreme.ex
+++ b/lib/extreme.ex
@@ -9,7 +9,6 @@ defmodule Commanded.EventStore.Adapters.Extreme do
   require Logger
 
   use GenServer
-  use Commanded.EventStore.Serializer
 
   alias Commanded.EventStore.{
     EventData,
@@ -19,9 +18,11 @@ defmodule Commanded.EventStore.Adapters.Extreme do
   alias Commanded.EventStore.Adapters.Extreme.{Config,Subscription}
   alias Commanded.EventStore.TypeProvider
   alias Extreme.Msg, as: ExMsg
+  alias Commanded.EventStore.Adapters.Extreme.Config
 
   @event_store Commanded.EventStore.Adapters.Extreme.EventStore
   @stream_prefix Config.stream_prefix()
+  @serializer Config.serializer()
 
   defmodule State do
     defstruct [

--- a/lib/extreme.ex
+++ b/lib/extreme.ex
@@ -67,7 +67,7 @@ defmodule Commanded.EventStore.Adapters.Extreme do
     GenServer.call(__MODULE__, {:subscribe_all, subscription_name, subscriber, start_from})
   end
 
-  @spec ack_event(pid, RecordedEvent.t) :: any
+  @spec ack_event(pid, RecordedEvent.t) :: :ok
   def ack_event(subscription, %RecordedEvent{event_number: event_number}) do
     Subscription.ack(subscription, event_number)
   end

--- a/lib/extreme/config.ex
+++ b/lib/extreme/config.ex
@@ -1,14 +1,21 @@
 defmodule Commanded.EventStore.Adapters.Extreme.Config do
   def event_store_settings do
-    Application.get_env(:extreme, :event_store) || raise ArgumentError, "expects :extreme to be configured in environment"
+    Application.get_env(:extreme, :event_store) ||
+      raise ArgumentError, "expects :extreme to be configured in environment"
   end
 
   def stream_prefix do
-    prefix = Application.get_env(:commanded_extreme_adapter, :stream_prefix) || raise ArgumentError, "expects :stream_prefix to be configured in environment"
+    prefix = Application.get_env(:commanded_extreme_adapter, :stream_prefix) ||
+      raise ArgumentError, "expects :stream_prefix to be configured in environment"
 
     case String.contains?(prefix, "-") do
       true -> raise ArgumentError, ":stream_prefix cannot contain a dash (\"-\")"
       false -> prefix
     end
+  end
+
+  def serializer do
+    Application.get_env(:commanded_extreme_adapter, :serializer) ||
+      raise ArgumentError, "expects :serializer to be configured in environment"
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -53,7 +53,7 @@ Extreme event store adapter for Commanded
       ],
       maintainers: ["Ben Smith"],
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/slashdotdash/commanded-extreme-adapter",
+      links: %{"GitHub" => "https://github.com/commanded/commanded-extreme-adapter",
                "Docs" => "https://hexdocs.pm/commanded_extreme_adapter/"}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Commanded.EventStore.Adapters.Extreme.Mixfile do
     [
       app: :commanded_extreme_adapter,
       version: "0.4.0",
-      elixir: "~> 1.4",
+      elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env),
       description: description(),
       package: package(),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Commanded.EventStore.Adapters.Extreme.Mixfile do
   def project do
     [
       app: :commanded_extreme_adapter,
-      version: "0.3.0",
+      version: "0.4.0",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env),
       description: description(),
@@ -29,7 +29,7 @@ defmodule Commanded.EventStore.Adapters.Extreme.Mixfile do
 
   defp deps do
     [
-      {:commanded, "~> 0.14", runtime: false},
+      {:commanded, ">= 0.15.0", runtime: false},
       {:docker, github: "bearice/elixir-docker", tag: "03809fc594b9706c106fc28b7ef03c2dbde2fe93", only: :test},
       {:extreme, "~> 0.10"},
       {:ex_doc, "~> 0.15", only: :dev},


### PR DESCRIPTION
Required to support Commanded v0.15.0