### PR TITLE
Supervisor for Subscription processes

### DIFF
--- a/lib/extreme/application.ex
+++ b/lib/extreme/application.ex
@@ -11,6 +11,7 @@ defmodule Commanded.EventStore.Adapters.Extreme.Application do
         Config.event_store_settings(),
         [name: Commanded.EventStore.Adapters.Extreme.EventStore]
       ]),
+      supervisor(Commanded.EventStore.Adapters.Extreme.SubscriptionsSupervisor, []),
       worker(Commanded.EventStore.Adapters.Extreme, [])
     ]
 

--- a/lib/extreme/application.ex
+++ b/lib/extreme/application.ex
@@ -11,8 +11,7 @@ defmodule Commanded.EventStore.Adapters.Extreme.Application do
         Config.event_store_settings(),
         [name: Commanded.EventStore.Adapters.Extreme.EventStore]
       ]),
-      supervisor(Commanded.EventStore.Adapters.Extreme.SubscriptionsSupervisor, []),
-      worker(Commanded.EventStore.Adapters.Extreme, [])
+      supervisor(Commanded.EventStore.Adapters.Extreme.SubscriptionsSupervisor, [])
     ]
 
     opts = [strategy: :one_for_one, name: Commanded.EventStore.Adapters.Extreme.Supervisor]

--- a/lib/extreme/subscription.ex
+++ b/lib/extreme/subscription.ex
@@ -30,8 +30,8 @@ defmodule Commanded.EventStore.Adapters.Extreme.Subscription do
   @doc """
   Start a process to create and connect a persistent connection to the Event Store
   """
-  def start(stream, subscription_name, subscriber, start_from) do
-    GenServer.start(__MODULE__, %State{
+  def start_link(stream, subscription_name, subscriber, start_from) do
+    GenServer.start_link(__MODULE__, %State{
       stream: stream,
       name: subscription_name,
       subscriber: subscriber,

--- a/lib/extreme/subscriptions_supervisor.ex
+++ b/lib/extreme/subscriptions_supervisor.ex
@@ -1,0 +1,40 @@
+defmodule Commanded.EventStore.Adapters.Extreme.SubscriptionsSupervisor do
+  use Supervisor
+  require Logger
+
+  alias Commanded.EventStore.Adapters.Extreme.Subscription
+
+  def start_link do
+    Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  def init(:ok) do
+    children = []
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  def start_subscription(stream, subscription_name, subscriber, start_from) do
+    Supervisor.start_child(
+      __MODULE__,
+      subscription_spec(stream, subscription_name, subscriber, start_from)
+    )
+    |> case  do
+      {:error, :already_present} -> Supervisor.restart_child(__MODULE__, subscription_name)
+      other -> other
+    end
+  end
+
+  def stop_subscription(subscription_name) do
+    Supervisor.terminate_child(__MODULE__, subscription_name)
+  end
+
+  defp subscription_spec(stream, subscription_name, subscriber, start_from) do
+    Supervisor.Spec.worker(
+      Subscription,
+      [stream, subscription_name, subscriber, start_from],
+      id: subscription_name,
+      restart: :transient,
+    )
+  end
+end


### PR DESCRIPTION
This PR adds a `SubscriptionsSupervisor`, which is responsible for keeping track of the currently started Subscriptions.

This removes the need for manual bookkeeping in `Commanded.EventStore.Adapters.Extreme` and we can port it from a GenServer to a plain module.

This fixes an issue where `Commanded.EventStore.Adapters.Extreme` could crash and forget about the subscriptions that were already started, which could cause duplicate Subscription-processes to be started, until the maximum subscriber count of EventStore is reached.

Please feel free to make any adjustments :-)