### PR TITLE
Raise loglevel of wrong expected version

### DIFF
--- a/lib/extreme.ex
+++ b/lib/extreme.ex
@@ -215,7 +215,7 @@ defmodule Commanded.EventStore.Adapters.Extreme do
         {:ok, response.last_event_number + 1}
 
       {:error, :WrongExpectedVersion, detail} ->
-        Logger.info(fn ->
+        Logger.warn(fn ->
           "Extreme eventstore wrong expected version \"#{expected_version}\" due to: #{
             inspect(detail)
           }"


### PR DESCRIPTION
As this might well stall a system the log level should be higher.

We have seen this issue kill our Commanded system completely as no new events were appended until we completely removed the stream from EventStore and restarted our application