### PR TITLE
Link subscriber to subscription

### DIFF
--- a/lib/extreme/subscription.ex
+++ b/lib/extreme/subscription.ex
@@ -50,6 +50,7 @@ defmodule Commanded.EventStore.Adapters.Extreme.Subscription do
   end
 
   def init(%State{subscriber: subscriber} = state) do
+    Process.link(subscriber)
     state = %State{state |
       subscriber_ref: Process.monitor(subscriber),
     }


### PR DESCRIPTION
Otherwise a dying subscription leaves the subscriber alive.