### PR TITLE
Remove prefix completely

### DIFF
--- a/lib/extreme.ex
+++ b/lib/extreme.ex
@@ -26,7 +26,6 @@ defmodule Commanded.EventStore.Adapters.Extreme do
   alias Extreme.Msg, as: ExMsg
 
   @event_store Commanded.EventStore.Adapters.Extreme.EventStore
-  @stream_prefix Config.stream_prefix()
   @serializer Config.serializer()
 
   @spec append_to_stream(String.t(), non_neg_integer, list(EventData.t())) ::
@@ -82,7 +81,7 @@ defmodule Commanded.EventStore.Adapters.Extreme do
   def subscribe_to_all_streams(subscription_name, subscriber, start_from \\ :origin)
 
   def subscribe_to_all_streams(subscription_name, subscriber, start_from) do
-    stream = "$ce-" <> @stream_prefix
+    stream = "$all"
 
     case SubscriptionsSupervisor.start_subscription(
            stream,
@@ -177,11 +176,9 @@ defmodule Commanded.EventStore.Adapters.Extreme do
     )
   end
 
-  defp prefix(suffix), do: @stream_prefix <> "-" <> suffix
+  defp snapshot_stream(source_uuid), do: "snapshot-" <> source_uuid
 
-  defp snapshot_stream(source_uuid), do: @stream_prefix <> "snapshot-" <> source_uuid
-
-  defp stream_name(stream), do: prefix(stream)
+  defp stream_name(stream), do: stream
 
   defp normalize_start_version(0), do: 0
   defp normalize_start_version(start_version), do: start_version - 1

--- a/lib/extreme/application.ex
+++ b/lib/extreme/application.ex
@@ -25,7 +25,7 @@ defmodule Commanded.EventStore.Adapters.Extreme.Application do
         start:
           {EventPublisher, :start_link, [
             @event_store,
-            "$ce-" <> Config.stream_prefix(),
+            "$all",
             [name: EventPublisher]
           ]},
         restart: :permanent,

--- a/lib/extreme/config.ex
+++ b/lib/extreme/config.ex
@@ -4,16 +4,6 @@ defmodule Commanded.EventStore.Adapters.Extreme.Config do
       raise ArgumentError, "expects :extreme to be configured in environment"
   end
 
-  def stream_prefix do
-    prefix = Application.get_env(:commanded_extreme_adapter, :stream_prefix) ||
-      raise ArgumentError, "expects :stream_prefix to be configured in environment"
-
-    case String.contains?(prefix, "-") do
-      true -> raise ArgumentError, ":stream_prefix cannot contain a dash (\"-\")"
-      false -> prefix
-    end
-  end
-
   def serializer do
     Application.get_env(:commanded_extreme_adapter, :serializer) ||
       raise ArgumentError, "expects :serializer to be configured in environment"


### PR DESCRIPTION
I got rid of the prefix, replacing it with the `$all` stream. This works for loading aggregates pretty well, which is all I really need. Allows me to do projections in Greg's EventStore correctly (e.g. by using `$ce-aggregate_name`.

Did *not* test:

- event handlers
- process managers