### PR TITLE
Skip deleted events instead of crashing

### DIFF
--- a/lib/extreme/subscription.ex
+++ b/lib/extreme/subscription.ex
@@ -101,7 +101,7 @@ defmodule Commanded.EventStore.Adapters.Extreme.Subscription do
       end
 
     state =
-      if "$" != String.first(event_type) do
+      if event_type != nil and "$" != String.first(event_type) do
         %RecordedEvent{event_number: event_number} =
           recorded_event = Mapper.to_recorded_event(event)
 


### PR DESCRIPTION
I tried to delete an event stream. The $ce-x subscription still provides the event but with the following:
```
16:18:55.528 [debug] Persistent subscription "$ce-x::X" event appeared: %Extreme.Msg.PersistentSubscriptionStreamEventAppeared{event: %Extreme.Msg.ResolvedIndexedEvent{event: %Extreme.Msg.EventRecord{created: nil, created_epoch: nil, data: nil, data_content_type: nil, event_id: nil, event_number: nil, event_stream_id: nil, event_type: nil, metadata: nil, metadata_content_type: nil}, link: %Extreme.Msg.EventRecord{...
```
As opposed to a non-deleted stream event that gives:
```
16:18:55.515 [debug] Persistent subscription "$ce-x::X" event appeared: %Extreme.Msg.PersistentSubscriptionStreamEventAppeared{event: %Extreme.Msg.ResolvedIndexedEvent{event: %Extreme.Msg.EventRecord{created: 636838691641959360, created_epoch: 1548272364195, data: "...
```
This makes the code crash:
```
16:18:55.538 [error] GenServer {Commanded.EventStore.Adapters.Extreme.Subscription, "$ce-x", "X"} terminating
** (FunctionClauseError) no function clause matching in String.Unicode.next_grapheme_size/1
    (elixir) lib/elixir/unicode/unicode.ex:40: String.Unicode.next_grapheme_size(nil)
    (elixir) lib/string.ex:1693: String.first/1
    (commanded_extreme_adapter) lib/extreme/subscription.ex:104: Commanded.EventStore.Adapters.Extreme.Subscription.handle_info/2
    (stdlib) gen_server.erl:637: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:711: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```
since `event_type` is `nil` there.

I added a check to skip these deleted events instead of crashing.